### PR TITLE
Updating to use node version in shippableimages

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -3,7 +3,7 @@ language: node_js
 
 # version numbers, testing against two versions of node
 node_js:
-    - 0.10.25
+    - 0.10.33
 
 before_install:
     - node --version


### PR DESCRIPTION
node_js version 0.10.25 does not exist in shippable/minv2:latest or shippableimages/ubuntu1404_nodejs, requiring a time-consuming nvm install during the build.  Changing to 0.10.33, which is in the images.